### PR TITLE
Add AllWork Tag to TypeDef

### DIFF
--- a/Defs/WorkTypeDef/WorkTypes.xml
+++ b/Defs/WorkTypeDef/WorkTypes.xml
@@ -14,6 +14,7 @@
 		</relevantSkills>
 		<workTags>
 		  <li>Intellectual</li>
+		  <li>AllWork</li>
 		</workTags>
 	</WorkTypeDef>
 </Defs>


### PR DESCRIPTION
This prevents Royalty's "Lazy Guests" from doing this work.  For whatever reason, Tynan chose to explicitly define every work type except a few of them as "AllWork" instead of just defining Bedrest and a couple of others as "LazyWork" or something.

To the best of my knowledge, tags are backwards compatible so even for a general TypeDef which is the same across versions like this, it shouldn't be a problem.  And it'll mean that visiting guests who "don't do work" won't do zero normal work but still gleefully be willing to sit around hacking mechanoids all day.

Cheers.