### PR TITLE
Pull request: Update Japanese Translation on 22 Jul, 2021

### DIFF
--- a/Languages/Japanese/DefInjected/ThingDef/_Things_Mote.xml
+++ b/Languages/Japanese/DefInjected/ThingDef/_Things_Mote.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
 
-  <WTH_Mote_Charging.label>Mote</WTH_Mote_Charging.label>
-  <WTH_Mote_HealingCrossGreen.label>Mote</WTH_Mote_HealingCrossGreen.label>
+  <!--<WTH_Mote_Charging.label>Mote</WTH_Mote_Charging.label>-->
+  <!--<WTH_Mote_HealingCrossGreen.label>Mote</WTH_Mote_HealingCrossGreen.label>-->
   <WTH_Mote_Overdrive.label>Mote</WTH_Mote_Overdrive.label>
 
 </LanguageData>


### PR DESCRIPTION
- for 4.0.0 (1.3)

Note:
"WTH_Mote_Charging" and "WTH_Mote_HealingCrossGreen" are not required in RimWorld 1.3, but they are required in RimWorld 1.2.